### PR TITLE
Remove image feature from turbojpeg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2373,7 +2373,6 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291e4517c03ca0b7a6fc7b69a9c5a0034e268de7b5a4ddf21d26dcc4c9cbadaa"
 dependencies = [
- "image",
  "libc",
  "thiserror",
  "turbojpeg-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,6 @@ serde_urlencoded = "0.7.1"
 sha2 = "0.10.8"
 thumbhash = "0.1.0"
 tokio = { version = "1.38.0", features = ["macros", "net", "rt", "signal", "sync", "time"] }
-turbojpeg = { version = "1.1.0", features = ["image"] }
+turbojpeg = { version = "1.1.0" }
 walkdir = "2.5.0"
 webp = "0.2.6"


### PR DESCRIPTION
This is so we can use our own version of the image crate.