### PR TITLE
Replace jemalloc with mimalloc for better performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,11 +998,11 @@ dependencies = [
  "hex",
  "hmac",
  "image",
- "jemallocator",
  "kamadak-exif",
  "libavif-image",
  "lru",
  "memchr",
+ "mimalloc",
  "rand 0.9.1",
  "reqwest",
  "serde",
@@ -1084,26 +1084,6 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
-
-[[package]]
-name = "jemalloc-sys"
-version = "0.5.4+5.3.0-patched"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "jemallocator"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
-dependencies = [
- "jemalloc-sys",
- "libc",
-]
 
 [[package]]
 name = "jobserver"
@@ -1195,6 +1175,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88cd67e9de251c1781dbe2f641a1a3ad66eaae831b8a2c38fbdc5ddae16d4d"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libwebp-sys"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1260,6 +1250,15 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1791cbe101e95af5764f06f20f6760521f7158f69dbf9d6baf941ee1bf6bc40"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "mime"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,11 +32,11 @@ envy = "0.4.2"
 hex = "0.4.3"
 hmac = "0.12.1"
 image = { version = "0.25.6", default-features = false, features = ["avif", "png", "tiff"] }
-jemallocator = { version = "0.5.4" }
 kamadak-exif = "0.6.1"
 libavif-image = { version = "0.14.0", default-features = false, features = ["codec-dav1d"] }
 lru = "0.16.0"
 memchr = "2.7.5"
+mimalloc = { version = "0.1.47" }
 rand = "0.9.1"
 reqwest = "0.12.22"
 serde = { version = "1.0.219", features = ["derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ mod signature;
 mod singleflight;
 
 #[global_allocator]
-static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 #[derive(Deserialize)]
 struct EnvConfig {


### PR DESCRIPTION
## Summary
- Replace jemalloc allocator with mimalloc 0.1.47 for improved memory allocation performance
- Update global allocator in src/main.rs from jemallocator::Jemalloc to mimalloc::MiMalloc  
- Remove jemallocator dependency and add mimalloc dependency in Cargo.toml

## Test plan
- [x] Verify project compiles successfully with mimalloc
- [x] Run cargo fmt to ensure code formatting is correct
- [x] Run cargo test to ensure no regressions (0 tests currently)
- [x] Run cargo clippy to check for any warnings or errors

🤖 Generated with [Claude Code](https://claude.ai/code)