### PR TITLE
fix(pipeline): validate null config and null tasks before dereferencing

### DIFF
--- a/lib/pipeline.test.ts
+++ b/lib/pipeline.test.ts
@@ -147,6 +147,28 @@ describe("PipelineExecutor", () => {
   });
 
   describe("validation - structure", () => {
+    test("throws error when config is null", async () => {
+      const engine = createMockEngine();
+      const client = createMockClient();
+      const executor = new PipelineExecutor(
+        engine as never,
+        client as never,
+        mockS3Config,
+        {
+          maxTasks: 10,
+          enableFetch: false,
+          dimensionLimit: DEFAULT_DIMENSION_LIMIT,
+        },
+      );
+
+      await expect(
+        executor.execute(null as unknown as PipelineConfig, new Uint8Array([1, 2, 3])),
+      ).rejects.toThrow(HttpError);
+      await expect(
+        executor.execute(null as unknown as PipelineConfig, new Uint8Array([1, 2, 3])),
+      ).rejects.toThrow("config must be an object");
+    });
+
     test("throws error when tasks is not an array", async () => {
       const engine = createMockEngine();
       const client = createMockClient();
@@ -168,6 +190,30 @@ describe("PipelineExecutor", () => {
       );
       await expect(executor.execute(config, new Uint8Array([1, 2, 3]))).rejects.toThrow(
         "tasks must be an array",
+      );
+    });
+
+    test("throws error when task is null", async () => {
+      const engine = createMockEngine();
+      const client = createMockClient();
+      const executor = new PipelineExecutor(
+        engine as never,
+        client as never,
+        mockS3Config,
+        {
+          maxTasks: 10,
+          enableFetch: false,
+          dimensionLimit: DEFAULT_DIMENSION_LIMIT,
+        },
+      );
+
+      const config = { tasks: [null] } as unknown as PipelineConfig;
+
+      await expect(executor.execute(config, new Uint8Array([1, 2, 3]))).rejects.toThrow(
+        HttpError,
+      );
+      await expect(executor.execute(config, new Uint8Array([1, 2, 3]))).rejects.toThrow(
+        "task[0]: must be an object",
       );
     });
 

--- a/lib/pipeline.ts
+++ b/lib/pipeline.ts
@@ -106,6 +106,10 @@ export class PipelineExecutor {
   }
 
   private validateConfigStructure(config: PipelineConfig): void {
+    if (!config || typeof config !== "object") {
+      throw new HttpError(400, "config must be an object");
+    }
+
     if (!config.tasks || !Array.isArray(config.tasks)) {
       throw new HttpError(400, "tasks must be an array");
     }
@@ -124,6 +128,10 @@ export class PipelineExecutor {
     const seenIds = new Set<string>();
     for (let i = 0; i < config.tasks.length; i++) {
       const task = config.tasks[i]!;
+
+      if (!task || typeof task !== "object") {
+        throw new HttpError(400, `task[${i}]: must be an object`);
+      }
 
       if (!task.id || typeof task.id !== "string") {
         throw new HttpError(400, `task[${i}]: id is required`);


### PR DESCRIPTION
validateConfigStructure() previously assumed the parsed JSON body and every task were non-null objects. Bodies such as null or {"tasks": [null]} threw TypeError before an HttpError could be produced, so malformed pipeline input returned 500 rather than 400.

Add explicit null/object checks for the top-level config and each task element, plus corresponding tests.